### PR TITLE
[tip-calc] Update readme to include gif path

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,6 @@ Completed:
 * [x] Optional: Using locale-specific currency and currency thousands separators.
 * [x] Optional: Making sure the keyboard is always visible and the bill amount is always the first responder. This way the user doesn't have to tap anywhere to use this app. Just launch the app and start typing.
 
-![Video Walkthrough](name of your gif file.gif)
+![Video Walkthrough](code_path_tip_calc.gif)
 
 Note: to embed the gif file, just check your gif file into your repo and update the name of the file above.


### PR DESCRIPTION
Replace the gif placeholder in README with the new correct path
